### PR TITLE
Fix shapefile extent not shrinking

### DIFF
--- a/src/core/vector/qgsvectorlayereditbuffer.cpp
+++ b/src/core/vector/qgsvectorlayereditbuffer.cpp
@@ -802,6 +802,10 @@ bool QgsVectorLayerEditBuffer::commitChangesChangeAttributes( bool &attributesCh
       return false;
     }
 
+    // recompute extent for Shapefile
+    if ( L->storageType() == QLatin1String( "ESRI Shapefile" ) )
+      L->extent();
+
     if ( L->dataProvider()->changeGeometryValues( mChangedGeometries ) )
     {
       commitErrors << tr( "SUCCESS: %n geometries were changed.", "changed geometries count", mChangedGeometries.size() );


### PR DESCRIPTION
Upstream states that when updating existing features in a shapefile, the extent will not be correct and then recomputation must be forced.
https://gdal.org/drivers/vector/shapefile.html#spatial-extent

With this fix, the attached script will return the correct extent without uncommenting.
https://github.com/qgis/QGIS/files/13325893/bug_extent_of_shapefile.py.txt

Fixes #23661, #13985