### PR TITLE
Revert hue value conversion results in QgsColorWidget

### DIFF
--- a/src/gui/qgscolorwidgets.cpp
+++ b/src/gui/qgscolorwidgets.cpp
@@ -41,7 +41,7 @@
 
 #include <cmath>
 
-#define HUE_MAX 359
+#define HUE_MAX 360
 
 
 // TODO QGIS 4 remove typedef, QColor was qreal (double) and is now float


### PR DESCRIPTION
Revert hue value conversion results in QgsColorWidget back to version 3.38 or earlier.

Due to #58375, the number of rounding digits has changed, so the extreme value of each color by Hue value is now 59.83 increments of HUE_MAX, which is 359, divided by 6. In order to have the normal 60 increments, a HUE_MAX value of 360 would be appropriate.

Before applying #58375 (QGIS 3.38):
![fig1](https://github.com/user-attachments/assets/43250d05-83ad-44e1-9dfc-044eb3886b9c)

After applying #58375 (QGIS 3.40):
![fig2](https://github.com/user-attachments/assets/bb60d50c-138b-48f9-bce5-e0a0ef5524d8)

After changing HUE_MAX from 359 to 360:
![fig3](https://github.com/user-attachments/assets/daab3bd1-dbe6-47fd-8b81-28a30f85f203)
